### PR TITLE
add support for create({err | msg}, [props])

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 
-var assert = require('assert');
 var statuses = require('statuses');
 var inherits = require('util').inherits;
 
@@ -30,11 +29,13 @@ exports = module.exports = function (status, msg, props) {
     ? msg
     : new Error(msg || statuses[status || 500]);
   for (var key in props) err[key] = props[key];
-  err.status = err.statusCode = status || err.status || 500;
-  assert(statuses(err.status), 'invalid status code');
-  err.expose = 'number' === typeof err.status
-    && statuses[err.status]
-    && err.status < 500;
+
+  status = status || err.status;
+  err.status = err.statusCode = 'number' == typeof status && statuses[status]
+    ? status
+    : 500;
+
+  err.expose = err.status < 500;
   return err;
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -56,13 +56,27 @@ describe('HTTP Errors', function () {
     var _err = new Error('LOL');
     _err.status = 404;
     var err = create(_err);
+    assert.equal(err, _err);
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 404);
     assert.equal(err.expose, true);
 
     _err = new Error('LOL');
     err = create(_err);
+    assert.equal(err, _err);
     assert.equal(err.message, 'LOL');
+    assert.equal(err.status, 500);
+    assert.equal(err.statusCode, 500);
+    assert.equal(err.expose, false);
+  })
+
+
+  it('create(err) with invalid err.status', function () {
+    var _err = new Error('Connection refused');
+    _err.status = -1;
+    var err = create(_err);
+    assert.equal(err, _err);
+    assert.equal(err.message, 'Connection refused');
     assert.equal(err.status, 500);
     assert.equal(err.statusCode, 500);
     assert.equal(err.expose, false);


### PR DESCRIPTION
- add support for `create({err | msg}, [props])`

```
    ✓ create(status) 
    ✓ create(status, msg) 
    ✓ create(props) 
    ✓ create(msg, status) 
    ✓ create(msg) 
    ✓ create(msg, props) 
    ✓ create(err) 
    ✓ create(err) with invalid err.status 
    ✓ create(err, props) 
    ✓ create(status, err, props) 
    ✓ create(status, msg, props) 
```
- remove assert. `http.request` always throw error with status -1 when connect refuse, assert here will cover up the real problem.
