### PR TITLE
inherit using prototype injection, avoid classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,9 +44,10 @@ var codes = statuses.codes.filter(function (num) {
 codes.forEach(function (code) {
   if (code >= 500) {
     var ServerError = function ServerError(msg) {
-      Error.call(this);
-      this.message = msg || statuses[code];
-      Error.captureStackTrace(this, arguments.callee);
+      var self = new Error(msg != null ? msg : statuses[code])
+      Error.captureStackTrace(self, arguments.callee)
+      self.__proto__ = ServerError.prototype
+      return self
     }
     inherits(ServerError, Error);
     ServerError.prototype.status =
@@ -58,9 +59,10 @@ codes.forEach(function (code) {
   }
 
   var ClientError = function ClientError(msg) {
-    Error.call(this);
-    this.message = msg || statuses[code];
-    Error.captureStackTrace(this, arguments.callee);
+    var self = new Error(msg != null ? msg : statuses[code])
+    Error.captureStackTrace(self, arguments.callee)
+    self.__proto__ = ClientError.prototype
+    return self
   }
   inherits(ClientError, Error);
   ClientError.prototype.status =

--- a/test/test.js
+++ b/test/test.js
@@ -147,4 +147,15 @@ describe('HTTP Errors', function () {
     assert.equal(err.statusCode, 404);
     assert(err.stack);
   })
+
+  it('should preserve error [[Class]]', function () {
+    var err = new create('LOL');
+    assert.equal(Object.prototype.toString.call(err), '[object Error]')
+
+    var err = new create[404]();
+    assert.equal(Object.prototype.toString.call(err), '[object Error]')
+
+    var err = new create[500]();
+    assert.equal(Object.prototype.toString.call(err), '[object Error]')
+  })
 })


### PR DESCRIPTION
``` js
// this is good:
> Object.prototype.toString.call(require('http-errors')('x'))
'[object Error]'

// this is bad:
> Object.prototype.toString.call(new (require('http-errors')[404])('x'))
'[object Object]'

// this is *very* bad :)
> Object.prototype.toString.call(require('http-errors')[404]('x'))
'[object Undefined]'
```

ref: https://github.com/jshttp/jshttp.github.io/issues/35#issuecomment-54106646
