### PR TITLE
Ensure error names are always valid camel-cased identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var inherits = require('inherits');
 
 function toIdentifier(str) {
   return str.split(' ').map(function (token) {
-    return token.slice(0, 1).toUpperCase() + token.slice(1).toLowerCase();
+    return token.slice(0, 1).toUpperCase() + token.slice(1);
   }).join('').replace(/[^ _0-9a-z]/gi, '');
 }
 


### PR DESCRIPTION
Currently errors like `"I'm a teapot"` generate wonky names (in this case: `I'mateapot` instead of `ImATeapot`). This fix ensures that any name `statuses` throws at us is converted to a consistent camel-cased form.
