### PR TITLE
Use Error.name for more meaningful stacktraces

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ exports = module.exports = function httpError() {
     Error.captureStackTrace(err, httpError)
   }
 
+  var name = toIdentifier(statuses[status])
+  var clsName = name.match(/Error$/) ? name : name + 'Error'
+  err.name = clsName
   err.expose = status < 500;
   for (var key in props) err[key] = props[key];
   err.status = err.statusCode = status;
@@ -54,9 +57,13 @@ var codes = statuses.codes.filter(function (num) {
 });
 
 codes.forEach(function (code) {
+  var name = toIdentifier(statuses[code])
+  var clsName = name.match(/Error$/) ? name : name + 'Error'
+
   if (code >= 500) {
     var ServerError = function ServerError(msg) {
       var self = new Error(msg != null ? msg : statuses[code])
+      self.name = clsName
       Error.captureStackTrace(self, ServerError)
       self.__proto__ = ServerError.prototype
       return self
@@ -66,12 +73,13 @@ codes.forEach(function (code) {
     ServerError.prototype.statusCode = code;
     ServerError.prototype.expose = false;
     exports[code] =
-    exports[toIdentifier(statuses[code])] = ServerError
+    exports[name] = ServerError
     return;
   }
 
   var ClientError = function ClientError(msg) {
     var self = new Error(msg != null ? msg : statuses[code])
+    self.name = clsName
     Error.captureStackTrace(self, ClientError)
     self.__proto__ = ClientError.prototype
     return self
@@ -81,6 +89,6 @@ codes.forEach(function (code) {
   ClientError.prototype.statusCode = code;
   ClientError.prototype.expose = true;
   exports[code] =
-  exports[toIdentifier(statuses[code])] = ClientError
+  exports[name] = ClientError
   return;
 });

--- a/index.js
+++ b/index.js
@@ -2,6 +2,12 @@
 var statuses = require('statuses');
 var inherits = require('inherits');
 
+function toIdentifier(str) {
+  return str.split(' ').map(function (token) {
+    return token.slice(0, 1).toUpperCase() + token.slice(1)
+  }).join('').replace(/[^ _0-9a-z]/gi, '')
+}
+
 exports = module.exports = function httpError() {
   // so much arity going on ~_~
   var err;
@@ -60,7 +66,7 @@ codes.forEach(function (code) {
     ServerError.prototype.statusCode = code;
     ServerError.prototype.expose = false;
     exports[code] =
-    exports[statuses[code].replace(/\s+/g, '')] = ServerError;
+    exports[toIdentifier(statuses[code])] = ServerError
     return;
   }
 
@@ -75,6 +81,6 @@ codes.forEach(function (code) {
   ClientError.prototype.statusCode = code;
   ClientError.prototype.expose = true;
   exports[code] =
-  exports[statuses[code].replace(/\s+/g, '')] = ClientError;
+  exports[toIdentifier(statuses[code])] = ClientError
   return;
 });

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,7 @@ var create = require('..');
 describe('HTTP Errors', function () {
   it('create(status)', function () {
     var err = create(404);
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'Not Found');
     assert.equal(err.status, 404);
     assert.equal(err.statusCode, 404);
@@ -13,6 +14,7 @@ describe('HTTP Errors', function () {
 
   it('create(status, msg)', function () {
     var err = create(404, 'LOL');
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 404);
     assert.equal(err.statusCode, 404);
@@ -22,6 +24,7 @@ describe('HTTP Errors', function () {
     var err = create(404, {
       id: 1
     })
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'Not Found');
     assert.equal(err.status, 404);
     assert.equal(err.statusCode, 404);
@@ -33,6 +36,7 @@ describe('HTTP Errors', function () {
       id: 1
     });
     assert.equal(err.id, 1);
+    assert.equal(err.name, 'InternalServerError')
     assert.equal(err.message, 'Internal Server Error');
     assert.equal(err.status, 500);
     assert.equal(err.statusCode, 500);
@@ -40,6 +44,7 @@ describe('HTTP Errors', function () {
 
   it('create(msg, status)', function () {
     var err = create('LOL', 404);
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 404);
     assert.equal(err.statusCode, 404);
@@ -47,6 +52,7 @@ describe('HTTP Errors', function () {
 
   it('create(msg)', function () {
     var err = create('LOL');
+    assert.equal(err.name, 'InternalServerError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 500);
     assert.equal(err.statusCode, 500);
@@ -56,6 +62,7 @@ describe('HTTP Errors', function () {
     var err = create('LOL', {
       id: 1
     });
+    assert.equal(err.name, 'InternalServerError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 500);
     assert.equal(err.statusCode, 500);
@@ -67,6 +74,7 @@ describe('HTTP Errors', function () {
     _err.status = 404;
     var err = create(_err);
     assert.equal(err, _err);
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 404);
     assert.equal(err.expose, true);
@@ -74,6 +82,7 @@ describe('HTTP Errors', function () {
     _err = new Error('LOL');
     err = create(_err);
     assert.equal(err, _err);
+    assert.equal(err.name, 'InternalServerError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 500);
     assert.equal(err.statusCode, 500);
@@ -86,6 +95,7 @@ describe('HTTP Errors', function () {
     _err.status = -1;
     var err = create(_err);
     assert.equal(err, _err);
+    assert.equal(err.name, 'InternalServerError')
     assert.equal(err.message, 'Connection refused');
     assert.equal(err.status, 500);
     assert.equal(err.statusCode, 500);
@@ -98,6 +108,7 @@ describe('HTTP Errors', function () {
     var err = create(_err, {
       id: 1
     });
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 404);
     assert.equal(err.id, 1);
@@ -110,6 +121,7 @@ describe('HTTP Errors', function () {
       id: 1
     });
     assert.equal(err, _err);
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 404);
     assert.equal(err.statusCode, 404);
@@ -119,6 +131,7 @@ describe('HTTP Errors', function () {
     var err = create(404, 'LOL', {
       id: 1
     });
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'LOL');
     assert.equal(err.status, 404);
     assert.equal(err.statusCode, 404);
@@ -133,6 +146,7 @@ describe('HTTP Errors', function () {
 
   it('new create.NotFound()', function () {
     var err = new create.NotFound();
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'Not Found');
     assert.equal(err.status, 404);
     assert.equal(err.statusCode, 404);
@@ -142,6 +156,7 @@ describe('HTTP Errors', function () {
 
   it('new create.InternalServerError()', function () {
     var err = new create.InternalServerError();
+    assert.equal(err.name, 'InternalServerError')
     assert.equal(err.message, 'Internal Server Error');
     assert.equal(err.status, 500);
     assert.equal(err.statusCode, 500);
@@ -151,6 +166,7 @@ describe('HTTP Errors', function () {
 
   it('new create["404"]()', function () {
     var err = new create['404']();
+    assert.equal(err.name, 'NotFoundError')
     assert.equal(err.message, 'Not Found');
     assert.equal(err.status, 404);
     assert.equal(err.statusCode, 404);


### PR DESCRIPTION
~~This change is backwards-incompatible.~~

Currently all stack traces just call the error `Error`. It's more useful if the `Error.name` property is overridden with the actual name of the error instead.

Compare:

```
Error: Unknown filename "lol.jpg"
  at ...
```

versus:

```
Not Found: Unknown filename "lol.jpg"
  at ...
```

This change does exactly that.

~~Instead of using the name additionally as message, the errors now have an empty message by default (just like `Error`, `SyntaxError` etc). For example:~~

~~Before:~~

```
Error: Not Found
  at ...
```

~~Now:~~

```
Not Found
  at ...
```

~~(note no trailing colon -- just like the built-in errors).~~

~~This makes the change backwards incompatible, but I think this makes the behaviour more consistent with other error types and is worth it. `Error.message` wasn't meant to be used to identify errors anyway (that's what the numerical codes are for).~~

EDIT: I've adjusted the PR so it doesn't change the behaviour of `err.message`.