### PR TITLE
support "err instanceof http-errors" for all individual errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,17 +39,17 @@ exports = module.exports = function httpError() {
   }
 
   // constructor
-  var HttpError = exports[status]
+  var StatusError = exports[status]
 
   if (!err) {
     // create error
-    err = HttpError
-      ? new HttpError(msg)
+    err = StatusError
+      ? new StatusError(msg)
       : new Error(msg || statuses[status])
     Error.captureStackTrace(err, httpError)
   }
 
-  if (!HttpError || !(err instanceof HttpError)) {
+  if (!StatusError || !(err instanceof StatusError)) {
     // add properties to generic error
     err.expose = status < 500
     err.status = err.statusCode = status
@@ -63,6 +63,10 @@ exports = module.exports = function httpError() {
 
   return err;
 };
+var HttpError = exports;
+
+inherits(HttpError, Error);
+
 
 // create generic error objects
 var codes = statuses.codes.filter(function (num) {
@@ -86,7 +90,7 @@ codes.forEach(function (code) {
       })
       return self
     }
-    inherits(ServerError, Error);
+    inherits(ServerError, HttpError);
     ServerError.prototype.status =
     ServerError.prototype.statusCode = code;
     ServerError.prototype.expose = false;
@@ -107,7 +111,7 @@ codes.forEach(function (code) {
     })
     return self
   }
-  inherits(ClientError, Error);
+  inherits(ClientError, HttpError);
   ClientError.prototype.status =
   ClientError.prototype.statusCode = code;
   ClientError.prototype.expose = true;

--- a/test/test.js
+++ b/test/test.js
@@ -226,6 +226,18 @@ describe('HTTP Errors', function () {
     assert((new create['500']()) instanceof Error);
   })
 
+  it('should support err instanceof for individual statuses', function () {
+    assert(create(404) instanceof create['404']);
+    assert((new create['404']()) instanceof create['404']);
+    assert((new create['500']()) instanceof create['500']);
+  })
+
+  it('should support err instanceof HttpError', function () {
+    assert(create(404) instanceof create);
+    assert((new create['404']()) instanceof create);
+    assert((new create['500']()) instanceof create);
+  })
+
   it('should support util.isError()', function () {
     assert(util.isError(create(404)));
     assert(util.isError(new create['404']()));


### PR DESCRIPTION
Allows for a broader `instanceof` check. Rather than needing to check if an error is a specific status code type, one can check for a generic `HttpError` as well.

    var HttpError = require('http-errors');
    var notFoundError = HttpError(404);
    
    if (notFoundError instanceof HttpError) {
        // true
    }

    if (notFoundError instanceof HttpError['404']) {
        // true
    }

    if (notFoundError.name === 'NotFoundError') {
        // true
    }

   