### PR TITLE
drop support for node v0.6, support >= node v0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: node_js
 node_js:
-  - "0.6"
   - "0.8"
   - "0.10"
   - "0.12"
   - "1.0"
   - "1.8"
   - "2.0"
+  - "3.0"
+  - "4.0"
 sudo: false
+before_install:
+- ./test/scripts/ensure-compatible-npm.sh
 script:
-  - "test $TRAVIS_NODE_VERSION != '0.6' || npm test"
-  - "test $TRAVIS_NODE_VERSION  = '0.6' || npm run-script test-travis"
+  - "npm run-script test-travis"
 after_script:
   - "test $TRAVIS_NODE_VERSION = '0.10' && npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mocha": "1"
   },
   "engines": {
-    "node": ">= 0.6"
+    "node": ">= 0.8"
   },
   "scripts": {
     "test": "mocha --reporter spec --bail",

--- a/test/scripts/ensure-compatible-npm.sh
+++ b/test/scripts/ensure-compatible-npm.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -o nounset
+set -o errexit
+
+npm install semver
+if node -e "process.exit(require('semver').lt(process.argv[1], '1.3.7') ? 0 : 1)" $(npm -v); then
+  npm install -g npm@2
+  npm install -g npm
+fi
+npm uninstall semver


### PR DESCRIPTION
The latest open PRs fail Travis CI builds due to an issue with npm/dependencies. npm is not supported for node < v0.8, so we should bump the minimum version to v0.8 to stay consistent with npm.

Remove support for node 0.6 and set minimum version to v0.8 to allow for full npm support, as it requires >= v0.8. Added support for node v0.8 when npm version is < 1.3.7 with heavy inspiration from [mocha](https://github.com/mochajs/mocha/commit/5a793e403753f5665b13dfaf0a29897e23f5149c).