### PR TITLE
.status/.statusCode not always defined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,8 @@ function createError () {
   if (!HttpError || !(err instanceof HttpError)) {
     // add properties to generic error
     err.expose = status < 500
-    err.status = err.statusCode = status
   }
+  err.status = err.statusCode = status
 
   for (var key in props) {
     if (key !== 'status' && key !== 'statusCode') {


### PR DESCRIPTION
While working with [Csurf](https://github.com/expressjs/csurf), had instance where the token validation failed and `createError(403, ...)` called Later in processing the error found that the `403` code was NOT being saved in the error object.  This change ensure the `.status` and `.statusCode` are always set for an error.



