### PR TITLE
Assimilate status code from non-error objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function createError () {
   // so much arity going on ~_~
   var err
   var msg
-  var status = 500
+  var status
   var props = {}
   for (var i = 0; i < arguments.length; i++) {
     var arg = arguments[i]
@@ -70,6 +70,7 @@ function createError () {
         break
       case 'object':
         props = arg
+        status = status || props.status || props.statusCode
         break
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -93,6 +93,30 @@ describe('HTTP Errors', function () {
     assert.equal(err.id, 1)
   })
 
+  it('create(props) with status prop', function () {
+    var err = create({
+      id: 1,
+      status: 418
+    })
+    assert.equal(err.name, 'ImATeapotError')
+    assert.equal(err.message, "I'm a teapot")
+    assert.equal(err.status, 418)
+    assert.equal(err.statusCode, 418)
+    assert.equal(err.id, 1)
+  })
+
+  it('create(props) with statusCode prop', function () {
+    var err = create({
+      id: 1,
+      statusCode: 418
+    })
+    assert.equal(err.name, 'ImATeapotError')
+    assert.equal(err.message, "I'm a teapot")
+    assert.equal(err.status, 418)
+    assert.equal(err.statusCode, 418)
+    assert.equal(err.id, 1)
+  })
+
   it('create(msg, status)', function () {
     var err = create('LOL', 404)
     assert.equal(err.name, 'NotFoundError')
@@ -153,6 +177,18 @@ describe('HTTP Errors', function () {
     assert.equal(err.expose, false)
   })
 
+  it('create(status, err)', function () {
+    var _err = new Error('LOL')
+    _err.status = 404
+    var err = create(418, _err)
+    assert.equal(err, _err)
+    assert.equal(err.name, 'Error')
+    assert.equal(err.message, 'LOL')
+    assert.equal(err.status, 404)
+    assert.equal(err.statusCode, 404)
+    assert.equal(err.expose, true)
+  })
+
   it('create(err, props)', function () {
     var _err = new Error('LOL')
     _err.status = 404
@@ -167,10 +203,27 @@ describe('HTTP Errors', function () {
     assert.equal(err.expose, true)
   })
 
+  it('create(err, props) with status prop', function () {
+    var _err = new Error('LOL')
+    _err.status = 404
+    var err = create(_err, {
+      id: 1,
+      status: 418
+    })
+    assert.equal(err.name, 'Error')
+    assert.equal(err.message, 'LOL')
+    assert.equal(err.status, 404)
+    assert.equal(err.statusCode, 404)
+    assert.equal(err.id, 1)
+    assert.equal(err.expose, true)
+  })
+
   it('create(status, err, props)', function () {
     var _err = new Error('LOL')
-    var err = create(404, _err, {
-      id: 1
+    _err.status = 404
+    var err = create(418, _err, {
+      id: 1,
+      status: 410
     })
     assert.equal(err, _err)
     assert.equal(err.name, 'Error')


### PR DESCRIPTION
The createError factory is already fairly versatile. It accepts Error objects and assimilates their name/status/stack. It accepts numbers and strings (taking the appropriate status). And it also accepts objects, assimilating their properties.

However, when given an object that contains status or statusCode, it does not assimilate that value.

My particular use case is for errors that are received from various api libraries, particularly REST APIs and Swagger clients. These objects do not inherit from `Error`, but the quite frequently have a `status` property.

If this change is accepted, then the following errorware would be quite versatile indeed.

```
app.use((err, req, res, next) => next(createError(err)));
```

It would properly support the following middleware scenarios:
- `next(404)` -> would become http 404
- `next("Some Error")` -> would become an http 500
- `next(new Error("foo"))` -> would become http 500, with useful stack trace
- `next({status: 403, foo: "some error object thrown by an api client or library"})` -> would become http 403, assimilating other props

The first three use-cases are already supported by http-errors. The last scenario would make createErrors consistent across all types of input.

I currently accomplish it via: `createError(err.status || err.statusCode, err)` which handles all the use cases describe above. (Though it relies on the now deprecated usage of number as second argument.)

I can add tests if this change would be considered welcome.