### PR TITLE
Ensure status param takes precedence over error.status

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,13 +48,13 @@ function createError () {
   // so much arity going on ~_~
   var err
   var msg
-  var status = 500
+  var status
   var props = {}
   for (var i = 0; i < arguments.length; i++) {
     var arg = arguments[i]
     if (arg instanceof Error) {
       err = arg
-      status = err.status || err.statusCode || status
+      status = status || err.status || err.statusCode
       continue
     }
     switch (typeof arg) {


### PR DESCRIPTION
I _believe_ this is a bug.

Prior to this change:

```js
_err = new Error()
_err.status = 404
err = createError(500, _err) // err.status == 404
```

After this change (no tests modified):

```js
_err = new Error()
_err.status = 404
err = createError(500, _err) // err.status == 500
```