### PR TITLE
[Issue#52] ensure desc in nameFunc exist before accessing its propertie

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix error creating objects in some environments
+
 2018-07-30 / 1.7.0
 ==================
 

--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ function createServerErrorConstructor (HttpError, name, code) {
 function nameFunc (func, name) {
   var desc = Object.getOwnPropertyDescriptor(func, 'name')
 
-  if (desc.configurable) {
+  if (desc && desc.configurable) {
     desc.value = name
     Object.defineProperty(func, 'name', desc)
   }


### PR DESCRIPTION
more info https://github.com/jshttp/http-errors/issues/52
this change will assure that no error is thrown when desc is undefined, which occurs in ie 11