### PR TITLE
Loosen semver for inherits

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "repository": "jshttp/http-errors",
   "dependencies": {
     "depd": "~1.1.2",
-    "inherits": "2.0.3",
+    "inherits": "~2.0.3",
     "setprototypeof": "1.1.1",
     "statuses": ">= 1.5.0 < 2",
     "toidentifier": "1.0.0"


### PR DESCRIPTION
@dougwilson [https://github.com/isaacs/inherits](inherits) has been updated with a patch fix and while some of our client side packages have picked up this newer version, this package is locked to the older version.

This ends up bloating our client side js since we have duplicate versions of inherits if any package specifies `^2.0.4` ( although you could make the case that they could loosen their semver to accept ^2.0.3 ).

https://github.com/isaacs/inherits/compare/v2.0.3...v2.0.4

Can we loosen the semver requirement on inherits so that we don't have this issue?  Thanks!