### PR TITLE
feat: set status and statusCode as enumerable properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,14 +159,21 @@ function createClientErrorConstructor (HttpError, name, code) {
       writable: true
     })
 
+    ;['status', 'statusCode'].forEach(property => {
+      Object.defineProperty(err, property, {
+        enumerable: true,
+        configurable: true,
+        value: code,
+        writable: true
+      })
+    })
+
     return err
   }
 
   inherits(ClientError, HttpError)
   nameFunc(ClientError, className)
 
-  ClientError.prototype.status = code
-  ClientError.prototype.statusCode = code
   ClientError.prototype.expose = true
 
   return ClientError
@@ -207,14 +214,21 @@ function createServerErrorConstructor (HttpError, name, code) {
       writable: true
     })
 
+    ;['status', 'statusCode'].forEach(property => {
+      Object.defineProperty(err, property, {
+        enumerable: true,
+        configurable: true,
+        value: code,
+        writable: true
+      })
+    })
+
     return err
   }
 
   inherits(ServerError, HttpError)
   nameFunc(ServerError, className)
 
-  ServerError.prototype.status = code
-  ServerError.prototype.statusCode = code
   ServerError.prototype.expose = false
 
   return ServerError

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,3 @@
-
 process.env.NO_DEPRECATION = 'http-errors'
 
 var assert = require('assert')
@@ -319,30 +318,42 @@ describe('HTTP Errors', function () {
   })
 
   it('should preserve error [[Class]]', function () {
-    assert.strictEqual(Object.prototype.toString.call(createError('LOL')), '[object Error]')
-    assert.strictEqual(Object.prototype.toString.call(new createError[404]()), '[object Error]')
-    assert.strictEqual(Object.prototype.toString.call(new createError[500]()), '[object Error]')
+    assert.strictEqual(
+      Object.prototype.toString.call(createError('LOL')),
+      '[object Error]'
+    )
+    assert.strictEqual(
+      Object.prototype.toString.call(new createError[404]()),
+      '[object Error]'
+    )
+    assert.strictEqual(
+      Object.prototype.toString.call(new createError[500]()),
+      '[object Error]'
+    )
   })
 
   it('should support err instanceof Error', function () {
     assert(createError(404) instanceof Error)
-    assert((new createError['404']()) instanceof Error)
-    assert((new createError['500']()) instanceof Error)
+    assert(new createError['404']() instanceof Error)
+    assert(new createError['500']() instanceof Error)
   })
 
   it('should support err instanceof exposed constructor', function () {
     assert(createError(404) instanceof createError.NotFound)
     assert(createError(500) instanceof createError.InternalServerError)
-    assert((new createError['404']()) instanceof createError.NotFound)
-    assert((new createError['500']()) instanceof createError.InternalServerError)
-    assert((new createError.NotFound()) instanceof createError.NotFound)
-    assert((new createError.InternalServerError()) instanceof createError.InternalServerError)
+    assert(new createError['404']() instanceof createError.NotFound)
+    assert(new createError['500']() instanceof createError.InternalServerError)
+    assert(new createError.NotFound() instanceof createError.NotFound)
+    assert(
+      new createError.InternalServerError() instanceof
+        createError.InternalServerError
+    )
   })
 
   it('should support err instanceof HttpError', function () {
     assert(createError(404) instanceof createError.HttpError)
-    assert((new createError['404']()) instanceof createError.HttpError)
-    assert((new createError['500']()) instanceof createError.HttpError)
+    assert(new createError['404']() instanceof createError.HttpError)
+    assert(new createError['500']() instanceof createError.HttpError)
   })
 
   it('should support util.isError()', function () {
@@ -351,5 +362,21 @@ describe('HTTP Errors', function () {
     assert(util.isError(new createError['404']()))
     assert(util.isError(new createError['500']()))
     /* eslint-enable node/no-deprecated-api */
+  })
+
+  it('should not have the same serialization with different statuses', function () {
+    var err = new createError.NotFound('whoopsie')
+    assert.notStrictEqual(
+      JSON.stringify(err),
+      JSON.stringify(new createError.BadRequest('whoopsie'))
+    )
+  })
+
+  it('should have the same serialization with same statuses', function () {
+    var err = new createError.NotFound('whoopsie')
+    assert.strictEqual(
+      JSON.stringify(err),
+      JSON.stringify(new createError.NotFound('whoopsie'))
+    )
   })
 })


### PR DESCRIPTION
This PR sets status and statusCode properties as enumerable. This allows some tools to make easier error inspections.

Here is an example with the Jest framework where this PR can be useful : 
```js
  const err = createError(400, 'xxx')
  await expect(Promise.reject(err)).rejects.toMatchObject({
    status: 400,
    message: 'xxx'
  })
```

Without this PR, this test fail, which is quite counter-intuitive.
What do you think about it ? 