### PR TITLE
feat: Support custom properties for named constructors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ var err = createError(404, 'This video does not exist!')
 ```
 
 - `status: 500` - the status code as a number
-- `message` - the message of the error, defaulting to node's text for that status code.
+- `message` - the message of the error, defaulting to node's text for that status code
 - `properties` - custom properties to attach to the object
 
 ### createError([status], [error], [properties])
@@ -88,19 +88,36 @@ fs.readFile('foo.txt', function (err, buf) {
 - `error` - the error object to extend
 - `properties` - custom properties to attach to the object
 
-### new createError\[code || name\](\[msg]\))
+### new createError\[code || name\](\[message], [properties]\))
 
-Create a new error object with the given message `msg`.
+Create a new error object with the given message `message` and custom `properties`.
 The error object inherits from `createError.HttpError`.
 
 <!-- eslint-disable no-undef, no-unused-vars -->
 
 ```js
-var err = new createError.NotFound()
+var err = new createError.NotFound('Resource not found.', { path: '/page' })
 ```
 
 - `code` - the status code as a number
-- `name` - the name of the error as a "bumpy case", i.e. `NotFound` or `InternalServerError`.
+- `name` - the name of the error as a "bumpy case", i.e. `NotFound` or `InternalServerError`
+- `message` - the message of the error
+- `properties` - custom properties to attach to the object
+
+### new createError\[code || name\](\[properties]\))
+
+Create a new error object with the given custom `properties` and defaulting the `message` to node's text for that status code.
+The error object inherits from `createError.HttpError`.
+
+<!-- eslint-disable no-undef, no-unused-vars -->
+
+```js
+var err = new createError.NotFound({ path: '/page' })
+```
+
+- `code` - the status code as a number
+- `name` - the name of the error as a "bumpy case", i.e. `NotFound` or `InternalServerError`
+- `properties` - custom properties to attach to the object
 
 #### List of all constructors
 

--- a/index.js
+++ b/index.js
@@ -132,9 +132,20 @@ function createHttpErrorConstructor () {
 function createClientErrorConstructor (HttpError, name, code) {
   var className = name.match(/Error$/) ? name : name + 'Error'
 
-  function ClientError (message) {
+  function ClientError () {
+    var message = arguments[0]
+    var props = {}
+
+    // Manage arity
+    if (typeof arguments[0] === 'object') {
+      message = null
+      props = arguments[0]
+    } else if (typeof arguments[1] === 'object') {
+      props = arguments[1]
+    }
+
     // create the error object
-    var msg = message != null ? message : statuses[code]
+    var msg = typeof message === 'string' ? message : statuses[code]
     var err = new Error(msg)
 
     // capture a stack trace to the construction point
@@ -159,6 +170,13 @@ function createClientErrorConstructor (HttpError, name, code) {
       writable: true
     })
 
+    // Add additional properties, if any
+    for (var key in props) {
+      if (key !== 'status' && key !== 'statusCode' && key !== 'message') {
+        err[key] = props[key]
+      }
+    }
+
     return err
   }
 
@@ -180,9 +198,20 @@ function createClientErrorConstructor (HttpError, name, code) {
 function createServerErrorConstructor (HttpError, name, code) {
   var className = name.match(/Error$/) ? name : name + 'Error'
 
-  function ServerError (message) {
+  function ServerError () {
+    var message = arguments[0]
+    var props = {}
+
+    // Manage arity
+    if (typeof arguments[0] === 'object') {
+      message = null
+      props = arguments[0]
+    } else if (typeof arguments[1] === 'object') {
+      props = arguments[1]
+    }
+
     // create the error object
-    var msg = message != null ? message : statuses[code]
+    var msg = typeof message === 'string' ? message : statuses[code]
     var err = new Error(msg)
 
     // capture a stack trace to the construction point
@@ -206,6 +235,13 @@ function createServerErrorConstructor (HttpError, name, code) {
       value: className,
       writable: true
     })
+
+    // Add additional properties, if any
+    for (var key in props) {
+      if (key !== 'status' && key !== 'statusCode' && key !== 'message') {
+        err[key] = props[key]
+      }
+    }
 
     return err
   }

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,3 @@
-
 process.env.NO_DEPRECATION = 'http-errors'
 
 var assert = require('assert')
@@ -298,6 +297,38 @@ describe('HTTP Errors', function () {
     assert(err.stack)
   })
 
+  it('new createError.NotFound(message)', function () {
+    var err = new createError.NotFound('LOL')
+    assert.strictEqual(err.name, 'NotFoundError')
+    assert.strictEqual(err.message, 'LOL')
+    assert.strictEqual(err.status, 404)
+    assert.strictEqual(err.statusCode, 404)
+    assert.strictEqual(err.expose, true)
+    assert(err.stack)
+  })
+
+  it('new createError.NotFound(props)', function () {
+    var err = new createError.NotFound({ id: 1 })
+    assert.strictEqual(err.name, 'NotFoundError')
+    assert.strictEqual(err.message, 'Not Found')
+    assert.strictEqual(err.status, 404)
+    assert.strictEqual(err.statusCode, 404)
+    assert.strictEqual(err.expose, true)
+    assert.strictEqual(err.id, 1)
+    assert(err.stack)
+  })
+
+  it('new createError.NotFound(message, props)', function () {
+    var err = new createError.NotFound('LOL', { id: 1 })
+    assert.strictEqual(err.name, 'NotFoundError')
+    assert.strictEqual(err.message, 'LOL')
+    assert.strictEqual(err.status, 404)
+    assert.strictEqual(err.statusCode, 404)
+    assert.strictEqual(err.expose, true)
+    assert.strictEqual(err.id, 1)
+    assert(err.stack)
+  })
+
   it('new createError.InternalServerError()', function () {
     var err = new createError.InternalServerError()
     assert.strictEqual(err.name, 'InternalServerError')
@@ -308,6 +339,38 @@ describe('HTTP Errors', function () {
     assert(err.stack)
   })
 
+  it('new createError.InternalServerError(message)', function () {
+    var err = new createError.InternalServerError('LOL')
+    assert.strictEqual(err.name, 'InternalServerError')
+    assert.strictEqual(err.message, 'LOL')
+    assert.strictEqual(err.status, 500)
+    assert.strictEqual(err.statusCode, 500)
+    assert.strictEqual(err.expose, false)
+    assert(err.stack)
+  })
+
+  it('new createError.InternalServerError(props)', function () {
+    var err = new createError.InternalServerError({ id: 1 })
+    assert.strictEqual(err.name, 'InternalServerError')
+    assert.strictEqual(err.message, 'Internal Server Error')
+    assert.strictEqual(err.status, 500)
+    assert.strictEqual(err.statusCode, 500)
+    assert.strictEqual(err.expose, false)
+    assert.strictEqual(err.id, 1)
+    assert(err.stack)
+  })
+
+  it('new createError.InternalServerError(message, props)', function () {
+    var err = new createError.InternalServerError('LOL', { id: 1 })
+    assert.strictEqual(err.name, 'InternalServerError')
+    assert.strictEqual(err.message, 'LOL')
+    assert.strictEqual(err.status, 500)
+    assert.strictEqual(err.statusCode, 500)
+    assert.strictEqual(err.expose, false)
+    assert.strictEqual(err.id, 1)
+    assert(err.stack)
+  })
+
   it('new createError["404"]()', function () {
     var err = new createError['404']()
     assert.strictEqual(err.name, 'NotFoundError')
@@ -315,6 +378,80 @@ describe('HTTP Errors', function () {
     assert.strictEqual(err.status, 404)
     assert.strictEqual(err.statusCode, 404)
     assert.strictEqual(err.expose, true)
+    assert(err.stack)
+  })
+
+  it('new createError["404"](message)', function () {
+    var err = new createError['404']('LOL')
+    assert.strictEqual(err.name, 'NotFoundError')
+    assert.strictEqual(err.message, 'LOL')
+    assert.strictEqual(err.status, 404)
+    assert.strictEqual(err.statusCode, 404)
+    assert.strictEqual(err.expose, true)
+    assert(err.stack)
+  })
+
+  it('new createError["404"](props)', function () {
+    var err = new createError['404']({ id: 1 })
+    assert.strictEqual(err.name, 'NotFoundError')
+    assert.strictEqual(err.message, 'Not Found')
+    assert.strictEqual(err.status, 404)
+    assert.strictEqual(err.statusCode, 404)
+    assert.strictEqual(err.expose, true)
+    assert.strictEqual(err.id, 1)
+    assert(err.stack)
+  })
+
+  it('new createError["404"](message, props)', function () {
+    var err = new createError['404']('LOL', { id: 1 })
+    assert.strictEqual(err.name, 'NotFoundError')
+    assert.strictEqual(err.message, 'LOL')
+    assert.strictEqual(err.status, 404)
+    assert.strictEqual(err.statusCode, 404)
+    assert.strictEqual(err.expose, true)
+    assert.strictEqual(err.id, 1)
+    assert(err.stack)
+  })
+
+  it('new createError["500"]()', function () {
+    var err = new createError['500']()
+    assert.strictEqual(err.name, 'InternalServerError')
+    assert.strictEqual(err.message, 'Internal Server Error')
+    assert.strictEqual(err.status, 500)
+    assert.strictEqual(err.statusCode, 500)
+    assert.strictEqual(err.expose, false)
+    assert(err.stack)
+  })
+
+  it('new createError["500"](message)', function () {
+    var err = new createError['500']('LOL')
+    assert.strictEqual(err.name, 'InternalServerError')
+    assert.strictEqual(err.message, 'LOL')
+    assert.strictEqual(err.status, 500)
+    assert.strictEqual(err.statusCode, 500)
+    assert.strictEqual(err.expose, false)
+    assert(err.stack)
+  })
+
+  it('new createError["500"](props)', function () {
+    var err = new createError['500']({ id: 1 })
+    assert.strictEqual(err.name, 'InternalServerError')
+    assert.strictEqual(err.message, 'Internal Server Error')
+    assert.strictEqual(err.status, 500)
+    assert.strictEqual(err.statusCode, 500)
+    assert.strictEqual(err.expose, false)
+    assert.strictEqual(err.id, 1)
+    assert(err.stack)
+  })
+
+  it('new createError["500"](message, props)', function () {
+    var err = new createError['500']('LOL', { id: 1 })
+    assert.strictEqual(err.name, 'InternalServerError')
+    assert.strictEqual(err.message, 'LOL')
+    assert.strictEqual(err.status, 500)
+    assert.strictEqual(err.statusCode, 500)
+    assert.strictEqual(err.expose, false)
+    assert.strictEqual(err.id, 1)
     assert(err.stack)
   })
 


### PR DESCRIPTION
This PR adds support for providing custom properties to named constructors, meaning that the two following constructor forms are introduced:

```
new createError[code || name]([properties]))
new createError[code || name]([message], [properties]))
```

The change is retro-compatible and has been also tested.

This fixes #29 and #51. 