### PR TITLE
Release 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           node-version: "16.13"
 
         - name: Node.js 17.x
-          node-version: "17.1"
+          node-version: "17.2"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         name:
-        - Node.js 0.6
         - Node.js 0.8
         - Node.js 0.10
         - Node.js 0.12
@@ -33,11 +32,6 @@ jobs:
         - Node.js 17.x
 
         include:
-        - name: Node.js 0.6
-          node-version: "0.6"
-          npm-i: mocha@1.21.5
-          npm-rm: nyc
-
         - name: Node.js 0.8
           node-version: "0.8"
           npm-i: mocha@2.5.3
@@ -119,21 +113,11 @@ jobs:
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
       run: |
-        if [[ "${{ matrix.node-version }}" == 0.6* ]]; then
-          sudo apt-get install g++-4.8 gcc-4.8 libssl1.0-dev
-          export CC=/usr/bin/gcc-4.8
-          export CXX=/usr/bin/g++-4.8
-        fi
         nvm install --default ${{ matrix.node-version }}
         if [[ "${{ matrix.node-version }}" == 0.* && "$(cut -d. -f2 <<< "${{ matrix.node-version }}")" -lt 10 ]]; then
           nvm install --alias=npm 0.10
           nvm use ${{ matrix.node-version }}
-          if [[ "$(npm -v)" == 1.1.* ]]; then
-            nvm exec npm npm install -g npm@1.1
-            ln -fs "$(which npm)" "$(dirname "$(nvm which npm)")/npm"
-          else
-            sed -i '1s;^.*$;'"$(printf '#!%q' "$(nvm which npm)")"';' "$(readlink -f "$(which npm)")"
-          fi
+          sed -i '1s;^.*$;'"$(printf '#!%q' "$(nvm which npm)")"';' "$(readlink -f "$(which npm)")"
           npm config set strict-ssl false
         fi
         dirname "$(nvm which ${{ matrix.node-version }})" >> "$GITHUB_PATH"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,9 +3,14 @@
 
   * Drop support for Node.js 0.6
   * Remove `I'mateapot` export; use `ImATeapot` instead
+  * Rename `UnorderedCollection` constructor to `TooEarly`
   * deps: depd@2.0.0
     - Replace internal `eval` usage with `Function` constructor
     - Use instance methods on `process` to check for listeners
+  * deps: statuses@2.0.1
+    - Fix messaging casing of `418 I'm a Teapot`
+    - Remove code 306
+    - Rename `425 Unordered Collection` to standard `425 Too Early`
 
 2021-11-14 / 1.8.1
 ==================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 2.x
 ===
 
+  * Drop support for Node.js 0.6
   * Remove `I'mateapot` export; use `ImATeapot` instead
 
 2021-11-14 / 1.8.1

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 
   * Drop support for Node.js 0.6
   * Remove `I'mateapot` export; use `ImATeapot` instead
+  * Remove support for status being non-first argument
   * Rename `UnorderedCollection` constructor to `TooEarly`
   * deps: depd@2.0.0
     - Replace internal `eval` usage with `Function` constructor

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.x
+===
+
+  * Remove `I'mateapot` export; use `ImATeapot` instead
+
 2021-11-14 / 1.8.1
 ==================
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 
   * Drop support for Node.js 0.6
   * Remove `I'mateapot` export; use `ImATeapot` instead
+  * deps: depd@2.0.0
+    - Replace internal `eval` usage with `Function` constructor
+    - Use instance methods on `process` to check for listeners
 
 2021-11-14 / 1.8.1
 ==================

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ var err = new createError.NotFound()
 |422        |UnprocessableEntity          |
 |423        |Locked                       |
 |424        |FailedDependency             |
-|425        |UnorderedCollection          |
+|425        |TooEarly                     |
 |426        |UpgradeRequired              |
 |428        |PreconditionRequired         |
 |429        |TooManyRequests              |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a [Node.js](https://nodejs.org/en/) module available through the
 [npm registry](https://www.npmjs.com/). Installation is done using the
 [`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):
 
-```bash
+```console
 $ npm install http-errors
 ```
 

--- a/index.js
+++ b/index.js
@@ -281,10 +281,6 @@ function populateConstructorExports (exports, codes, HttpError) {
       exports[name] = CodeError
     }
   })
-
-  // backwards-compatibility
-  exports["I'mateapot"] = deprecate.function(exports.ImATeapot,
-    '"I\'mateapot"; use "ImATeapot" instead')
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function createError () {
   }
 
   if (typeof status !== 'number' ||
-    (!statuses[status] && (status < 400 || status >= 600))) {
+    (!statuses.message[status] && (status < 400 || status >= 600))) {
     status = 500
   }
 
@@ -91,7 +91,7 @@ function createError () {
     // create error
     err = HttpError
       ? new HttpError(msg)
-      : new Error(msg || statuses[status])
+      : new Error(msg || statuses.message[status])
     Error.captureStackTrace(err, createError)
   }
 
@@ -135,7 +135,7 @@ function createClientErrorConstructor (HttpError, name, code) {
 
   function ClientError (message) {
     // create the error object
-    var msg = message != null ? message : statuses[code]
+    var msg = message != null ? message : statuses.message[code]
     var err = new Error(msg)
 
     // capture a stack trace to the construction point
@@ -204,7 +204,7 @@ function createServerErrorConstructor (HttpError, name, code) {
 
   function ServerError (message) {
     // create the error object
-    var msg = message != null ? message : statuses[code]
+    var msg = message != null ? message : statuses.message[code]
     var err = new Error(msg)
 
     // capture a stack trace to the construction point
@@ -264,7 +264,7 @@ function nameFunc (func, name) {
 function populateConstructorExports (exports, codes, HttpError) {
   codes.forEach(function forEachCode (code) {
     var CodeError
-    var name = toIdentifier(statuses[code])
+    var name = toIdentifier(statuses.message[code])
 
     switch (codeClass(code)) {
       case 400:

--- a/index.js
+++ b/index.js
@@ -54,24 +54,18 @@ function createError () {
   var props = {}
   for (var i = 0; i < arguments.length; i++) {
     var arg = arguments[i]
-    if (arg instanceof Error) {
+    var type = typeof arg
+    if (type === 'object' && arg instanceof Error) {
       err = arg
       status = err.status || err.statusCode || status
-      continue
-    }
-    switch (typeof arg) {
-      case 'string':
-        msg = arg
-        break
-      case 'number':
-        status = arg
-        if (i !== 0) {
-          deprecate('non-first-argument status code; replace with createError(' + arg + ', ...)')
-        }
-        break
-      case 'object':
-        props = arg
-        break
+    } else if (type === 'number' && i === 0) {
+      status = arg
+    } else if (type === 'string') {
+      msg = arg
+    } else if (type === 'object') {
+      props = arg
+    } else {
+      throw new TypeError('argument #' + (i + 1) + ' unsupported type ' + type)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "nyc": "15.1.0"
   },
   "engines": {
-    "node": ">= 0.6"
+    "node": ">= 0.8"
   },
   "scripts": {
     "lint": "eslint . && node ./scripts/lint-readme-list.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": "jshttp/http-errors",
   "dependencies": {
-    "depd": "~1.1.2",
+    "depd": "2.0.0",
     "inherits": "2.0.4",
     "setprototypeof": "1.2.0",
     "statuses": ">= 1.5.0 < 2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-markdown": "2.2.1",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-promise": "5.1.1",
+    "eslint-plugin-promise": "5.2.0",
     "eslint-plugin-standard": "4.1.0",
     "mocha": "9.1.3",
     "nyc": "15.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint": "eslint . && node ./scripts/lint-readme-list.js",
     "test": "mocha --reporter spec --bail",
     "test-ci": "nyc --reporter=lcov --reporter=text npm test",
-    "test-cov": "nyc --reporter=html --reporter=text npm test"
+    "test-cov": "nyc --reporter=html --reporter=text npm test",
+    "version": "node scripts/version-history.js && git add HISTORY.md"
   },
   "keywords": [
     "http",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "depd": "2.0.0",
     "inherits": "2.0.4",
     "setprototypeof": "1.2.0",
-    "statuses": ">= 1.5.0 < 2",
+    "statuses": "2.0.1",
     "toidentifier": "1.0.1"
   },
   "devDependencies": {

--- a/scripts/version-history.js
+++ b/scripts/version-history.js
@@ -1,0 +1,63 @@
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+
+var HISTORY_FILE_PATH = path.join(__dirname, '..', 'HISTORY.md')
+var MD_HEADER_REGEXP = /^====*$/
+var VERSION = process.env.npm_package_version
+var VERSION_PLACEHOLDER_REGEXP = /^(?:unreleased|(\d+\.)+x)$/
+
+var historyFileLines = fs.readFileSync(HISTORY_FILE_PATH, 'utf-8').split('\n')
+
+if (!MD_HEADER_REGEXP.test(historyFileLines[1])) {
+  console.error('Missing header in HISTORY.md')
+  process.exit(1)
+}
+
+if (!VERSION_PLACEHOLDER_REGEXP.test(historyFileLines[0])) {
+  console.error('Missing placeholder version in HISTORY.md')
+  process.exit(1)
+}
+
+if (historyFileLines[0].indexOf('x') !== -1) {
+  var versionCheckRegExp = new RegExp('^' + historyFileLines[0].replace('x', '.+') + '$')
+
+  if (!versionCheckRegExp.test(VERSION)) {
+    console.error('Version %s does not match placeholder %s', VERSION, historyFileLines[0])
+    process.exit(1)
+  }
+}
+
+historyFileLines[0] = VERSION + ' / ' + getLocaleDate()
+historyFileLines[1] = repeat('=', historyFileLines[0].length)
+
+fs.writeFileSync(HISTORY_FILE_PATH, historyFileLines.join('\n'))
+
+function getLocaleDate () {
+  var now = new Date()
+
+  return zeroPad(now.getFullYear(), 4) + '-' +
+    zeroPad(now.getMonth() + 1, 2) + '-' +
+    zeroPad(now.getDate(), 2)
+}
+
+function repeat (str, length) {
+  var out = ''
+
+  for (var i = 0; i < length; i++) {
+    out += str
+  }
+
+  return out
+}
+
+function zeroPad (number, length) {
+  var num = number.toString()
+
+  while (num.length < length) {
+    num = '0' + num
+  }
+
+  return num
+}

--- a/test/test.js
+++ b/test/test.js
@@ -226,11 +226,9 @@ describe('HTTP Errors', function () {
   })
 
   it('createError(msg, status)', function () {
-    var err = createError('LOL', 404)
-    assert.strictEqual(err.name, 'NotFoundError')
-    assert.strictEqual(err.message, 'LOL')
-    assert.strictEqual(err.status, 404)
-    assert.strictEqual(err.statusCode, 404)
+    assert.throws(function () {
+      createError('LOL', 404)
+    }, /argument #2 unsupported type number/)
   })
 
   it('createError(msg)', function () {


### PR DESCRIPTION
This is a tracking issue for release 2.0.

**Please keep feature requests in their own issues**

If you want to make a comment on a particular change, please make the comment in the "Files changed" tab so comments are not lost during a rebase.

List of changes for release:
- [x] Drop support for Node.js 0.6
- [x] Remove deprecated "I'mateapot" export
- [x] Remove support for status being non-first argument #76
- [x] Upgrade `depd` to 2.0 #72 
- [x] Upgrade `statuses` to 2.0

**Testing this release**

If you want to try out this release, you can install it with the following commands:

``` bash
$ npm cache clean http-errors
$ npm install jshttp/http-errors#2.0
```

**Please do not merge until there is some kind of consensus / non-objection**