### PR TITLE
Upgrade depd and mocha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 node_modules
 coverage
 package-lock.json
+.idea

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": "jshttp/http-errors",
   "dependencies": {
-    "depd": "~1.1.2",
+    "depd": "^2.0.0",
     "inherits": "2.0.4",
     "setprototypeof": "1.2.0",
     "statuses": ">= 1.5.0 < 2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
-    "mocha": "8.0.1",
+    "mocha": "^8.2.1",
     "nyc": "15.1.0"
   },
   "engines": {


### PR DESCRIPTION
Upgrade depd and mocha. 

Upgrade depd to 2.0.0 since this version no longer uses `eval` function.

Upgrade mocha after running `npm audit`.