### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ function populateConstructorExports (exports, codes, HttpError) {
  */
 
 function toClassName (name) {
-  return name.substr(-5) !== 'Error'
+  return name.slice(-5) !== 'Error'
     ? name + 'Error'
     : name
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.