### PR TITLE
Improve warning for non-error status codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function createError () {
   }
 
   if (typeof status === 'number' && (status < 400 || status >= 600)) {
-    deprecate('non-error status code; use only 4xx or 5xx status codes')
+    deprecate('non-error status code ' + status + '; use only 4xx or 5xx status codes')
   }
 
   if (typeof status !== 'number' ||

--- a/test/test.js
+++ b/test/test.js
@@ -407,3 +407,17 @@ describe('HTTP Errors', function () {
     /* eslint-enable node/no-deprecated-api */
   })
 })
+
+describe('Deprecation notice', function () {
+  it('createError() deprecated', function (done) {
+    process.on('deprecation', (warning) => {
+      assert.strictEqual(warning.name, 'DeprecationError')
+      assert.strictEqual(warning.message, 'non-error status code 999; use only 4xx or 5xx status codes')
+      done()
+    })
+
+    createError(999, {
+      id: 1
+    })
+  })
+})


### PR DESCRIPTION
Includes the status code in the deprecation warning. It also adds a test to check if the warning is emitted. 