### PR TITLE
Jonchurch/prototype

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -178,6 +178,35 @@ describe('createError.isHttpError(val)', function () {
   })
 })
 
+describe('Subclass Instantiation', function () {
+  it('should allow instantiation of ClientError subclasses', function () {
+    assert.doesNotThrow(() => {
+      // eslint-disable-next-line no-new
+      new createError.NotFound()
+    })
+  })
+
+  it('should allow instantiation of ServerError subclasses', function () {
+    assert.doesNotThrow(() => {
+      // eslint-disable-next-line no-new
+      new createError.InternalServerError()
+    })
+  })
+})
+
+describe('Prototype Chain Adjustments', function () {
+  it('CustomError instances should have the correct prototype chain', function () {
+    class CustomError extends createError.NotFound {}
+    const err = new CustomError()
+    assert(err instanceof CustomError)
+    assert(err instanceof createError.NotFound)
+    // we don't export ClientError currently
+    // assert(err instanceof createError.ClientError)
+    assert(err instanceof createError.HttpError)
+    assert(err instanceof Error)
+  })
+})
+
 describe('HTTP Errors', function () {
   it('createError(status, props)', function () {
     var err = createError(404, {
@@ -336,7 +365,7 @@ describe('HTTP Errors', function () {
     assert.strictEqual(err.expose, false)
   })
 
-  it('new createError.HttpError()', function () {
+  it('should throw when directly instantiating HttpError', function () {
     assert.throws(function () {
       new createError.HttpError() // eslint-disable-line no-new
     }, /cannot construct abstract class/)


### PR DESCRIPTION
closes #98
## The Issue
### Extending `HttpError` is not possible currently because of the throw to prevent instantiating the abstract class.

```js
const createErrors = require('http-errors')

class NewBase extends createErrors.HttpError // extending HttpError will throw a type error here
// TypeError: cannot construct abstract class
```

### Extending error classes like `NotFound` do not wire up the prototype properly to be able to check `insanceof` on it.

```js
const createErrors = require('http-errors')

class ValidationError extends createErrors.BadRequest {}

assert(err instanceof ValidationError) // false
```
## The Change

This PR introduces adjustments to the prototype chain handling within our error creation utilities, specifically targeting the `createHttpErrorConstructor`, `createClientErrorConstructor`, and `createServerErrorConstructor` functions. These changes ensure that subclasses of the named HTTP error constructors, such as `NotFound`, correctly inherit properties and behaviors while maintaining the expected prototype chain.

## Key Changes:

- Utilized Reflect.construct within ClientError and ServerError constructors to dynamically set the prototype based on new.target, supporting correct inheritance for subclasses.
- Adjusted prototype setting logic to conditionally apply only when new.target differs from the constructor, preserving the intended prototype chain for subclasses.
 - Implemented a check in HttpError to prevent direct instantiation, enforcing its intended use as an abstract class, but allowing it to be subclassed.

Developers can now extend built-in HTTP error constuctors more intuitively, ensuring instances of custom errors are recognized as instances of their specific class as well as their HTTP error ancestors:

```js
const createErrors = require('http-errors')

class CustomError extends createErrors.NotFound {}

const err = new CustomError()

console.log(err instanceof CustomError) // true
console.log(err instanceof createErrors.NotFound) // true
console.log(err instanceof createErrors.HttpError) // true
```


HttpError instantiation change:

```js
// allows subclassing abstract HttpError
// extending this exported constructor would previously throw w/ TypeError: cannot construct abstract class
class CustomBaseHttpError extends createErrors.HttpError {}

const custom = new CustomBaseHttpError()

// direct instantion w/ new is still prevented and will throw
new createErrors.HttpError() // throws

// as is direct instantion via the factor functions
createErrors.HttpError()

```