### PR TITLE
Add test for extending native errors w/o altering prototype

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,24 @@ describe('createError(status)', function () {
     assert.ok(util.isError(createError(500))) // eslint-disable-line node/no-deprecated-api
   })
 
+  describe('Extending Existing Errors with HTTP Properties', function () {
+    it('should extend an existing error with HTTP properties without altering its prototype', function () {
+      const nativeError = new Error('This is a test error')
+
+      // Extend the error with HTTP semantics
+      const httpError = createError(404, nativeError, { expose: false })
+
+      assert.strictEqual(httpError.status, 404)
+      assert.strictEqual(httpError.expose, false)
+
+      assert.strictEqual(httpError.message, 'This is a test error')
+
+      assert(httpError instanceof Error)
+
+      assert.strictEqual(Object.getPrototypeOf(httpError), Error.prototype)
+    })
+  })
+
   describe('when status 300', function () {
     before(function () {
       this.error = createError(300)

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ describe('createError(status)', function () {
   })
 
   describe('Extending Existing Errors with HTTP Properties', function () {
-    it('should extend an existing error with HTTP properties without altering its prototype', function () {
+    it('should extend existing error without altering its prototype or replacing the object', function () {
       var nativeError = new Error('This is a test error')
 
       // Extend the error with HTTP semantics
@@ -26,6 +26,8 @@ describe('createError(status)', function () {
       assert(httpError instanceof Error)
 
       assert.strictEqual(Object.getPrototypeOf(httpError), Error.prototype)
+
+      assert.strictEqual(nativeError, httpError)
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('createError(status)', function () {
 
       assert.strictEqual(Object.getPrototypeOf(httpError), Error.prototype)
 
-      assert.strictEqual(nativeError, httpError)
+      assert.strictEqual(httpError, nativeError)
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -13,10 +13,10 @@ describe('createError(status)', function () {
 
   describe('Extending Existing Errors with HTTP Properties', function () {
     it('should extend an existing error with HTTP properties without altering its prototype', function () {
-      const nativeError = new Error('This is a test error')
+      var nativeError = new Error('This is a test error')
 
       // Extend the error with HTTP semantics
-      const httpError = createError(404, nativeError, { expose: false })
+      var httpError = createError(404, nativeError, { expose: false })
 
       assert.strictEqual(httpError.status, 404)
       assert.strictEqual(httpError.expose, false)


### PR DESCRIPTION
This adds a test to assert on behavior outlined in the docs but not captured in the test suite.

https://github.com/jshttp/http-errors?tab=readme-ov-file#createerrorstatus-error-properties

> ### createError([status], [error], [properties])
> 
> Extend the given `error` object with `createError.HttpError`
> properties. This will not alter the inheritance of the given
> `error` object, and the modified `error` object is the
> return value.