### PR TITLE
Remove inherits and setprototypeof dependenciess, use real classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
   "repository": "jshttp/http-errors",
   "dependencies": {
     "depd": "2.0.0",
-    "inherits": "2.0.4",
-    "setprototypeof": "1.2.0",
     "statuses": "2.0.1",
     "toidentifier": "1.0.1"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var assert = require('assert')
 var util = require('util')
 
 var createError = require('..')
+const { HttpError } = createError
 
 describe('createError(status)', function () {
   it('should create error object', function () {
@@ -405,5 +406,22 @@ describe('HTTP Errors', function () {
     assert(util.isError(new createError['404']()))
     assert(util.isError(new createError['500']()))
     /* eslint-enable node/no-deprecated-api */
+  })
+})
+
+describe('Inheritance', function () {
+  it('should support subclasses', function () {
+    class MyError extends HttpError {
+    }
+    const err = new MyError()
+    assert.ok(err instanceof HttpError, 'subclass instances are instances of HttpError')
+  })
+
+  it('should set status and message', function () {
+    class MyError extends HttpError {
+    }
+    const err = new MyError(202, 'My Error')
+    assert.strictEqual(err.status, 202)
+    assert.strictEqual(err.message, 'My Error')
   })
 })


### PR DESCRIPTION
Fixes https://github.com/jshttp/http-errors/issues/110 and https://github.com/jshttp/http-errors/issues/98

This converts the `HttpError` constructor function to a real class and the constructor factories to use subclasses. This removes the need for `inherits`. `setprototypeof` wasn't needed anymore with that change.

Changing to real classes fixes https://github.com/jshttp/http-errors/issues/98 as HttpError is now subclassable. The ban against direct instantiation of `HttpError` is re-implemented with a `new.target` check.