### PR TITLE
deps: update statuses and switch fixed versions to tilde (~)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@ Unreleased changes
 ==================
 
   * improve toClassName function readability and JSDoc completeness
+  * deps: use tilde notation for dependencies
+  * deps: update statuses to 2.0.2
 
 2.0.0 / 2021-12-17
 ==================

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "license": "MIT",
   "repository": "jshttp/http-errors",
   "dependencies": {
-    "depd": "2.0.0",
-    "inherits": "2.0.4",
-    "setprototypeof": "1.2.0",
-    "statuses": "2.0.1",
-    "toidentifier": "1.0.1"
+    "depd": "~2.0.0",
+    "inherits": "~2.0.4",
+    "setprototypeof": "~1.2.0",
+    "statuses": "~2.0.2",
+    "toidentifier": "~1.0.1"
   },
   "devDependencies": {
     "eslint": "7.32.0",


### PR DESCRIPTION
This PR updates the dependencies to use the tilde (`~`) notation and updates the `statuses` library to version `v2.0.2`.

The caret (`^`) notation is avoided due to compatibility issues with older Node.js environments where the default npm version does not support it.